### PR TITLE
Change default RandomForset input format to dense

### DIFF
--- a/examples/titanic_rf/queries/cardinality.sql
+++ b/examples/titanic_rf/queries/cardinality.sql
@@ -1,0 +1,5 @@
+select
+  array_max(array[approx_distinct(embarked), approx_distinct(sex), approx_distinct(pclass)]) as max_categorical_cardinality
+from
+  ${source}
+;

--- a/examples/titanic_rf/queries/evaluate.sql
+++ b/examples/titanic_rf/queries/evaluate.sql
@@ -1,15 +1,15 @@
 select
   auc(${predicted_column}, survived) as auc
   , logloss(${predicted_column}, survived) as logloss
+from
+  (
+    select
+      p.${predicted_column}, t.survived
     from
-      (
-  select
-    p.${predicted_column}, t.survived
-  from
-    ${predicted_table} p
-  join
-    ${actual} t on (p.rowid = t.rowid)
-  order by
-    probability desc
-) t2
+      ${predicted_table} p
+    join
+      ${actual} t on (p.rowid = t.rowid)
+    order by
+      probability desc
+  ) t2
 ;

--- a/examples/titanic_rf/queries/predict_randomforest_classifier.sql
+++ b/examples/titanic_rf/queries/predict_randomforest_classifier.sql
@@ -4,14 +4,14 @@ with ensembled as (
     rf_ensemble(predicted.value, predicted.posteriori, model_weight) as predicted
   from (
     select
-      t.rowid, 
+      t.rowid,
       p.model_weight,
-      tree_predict(p.model_id, p.model, feature_hashing(t.features) , "-classification") as predicted
+      tree_predict(p.model_id, p.model, feature_hashing(t.features), "-classification") as predicted
     from (
-      select 
+      select
         model_id, model_weight, model
-      from 
-        ${model_table} 
+      from
+        ${model_table}
       DISTRIBUTE BY rand(1)
     ) p
     left outer join ${target_table} t
@@ -20,7 +20,7 @@ with ensembled as (
     rowid
 )
 -- DIGDAG_INSERT_LINE
-select 
+select
   rowid,
   predicted.label,
   predicted.probabilities[1] as probability

--- a/examples/titanic_rf/queries/train_randomforest_classifier.sql
+++ b/examples/titanic_rf/queries/train_randomforest_classifier.sql
@@ -1,23 +1,9 @@
-with models as (
-  select
-    train_randomforest_classifier(
-      feature_hashing(features)
-      , survived
-      , '-trees 15 -seed 31'
-    )
-  from
-    ${source}
-)
--- DIGDAG_INSERT_LINE
 select
-  model_id
-  , model_weight
-  , model
-  , concat_ws(',', collect_set(concat(k1, ':', v1))) as var_importance
-  , oob_errors
-  , oob_tests
+  train_randomforest_classifier(
+    feature_hashing(features)
+    , survived
+    , '-trees 15 -seed 31 -attrs Q,Q,C,C,C'
+  )
 from
-  models
-lateral view explode(var_importance) t1 as k1, v1
-group by 1, 2, 3, 5, 6
+  ${source}
 ;

--- a/examples/titanic_rf/queries/vectorize_dense.sql
+++ b/examples/titanic_rf/queries/vectorize_dense.sql
@@ -1,0 +1,7 @@
+select
+  rowid
+  , array(age, fare, mhash(embarked, ${feature_cardinality}), mhash(sex, ${feature_cardinality}), mhash(pclass, ${feature_cardinality})) as features
+  , survived
+from
+  ${source}
+;

--- a/examples/titanic_rf/titanic_rf.dig
+++ b/examples/titanic_rf/titanic_rf.dig
@@ -1,5 +1,4 @@
 _export:
-  '!include': config/params.yml
   source: titanic
   train_sample_rate: 0.8
   td:
@@ -58,6 +57,11 @@ _export:
         engine: presto
         source: titanic_test
         create_table: titanic_imputed_test
++compute_cardinality:
+  td>: queries/cardinality.sql
+  engine: presto
+  source: titanic_imputed_train
+  store_last_results: true
 +vectorization:
   _parallel: true
   +whole:
@@ -72,22 +76,37 @@ _export:
     td>: queries/vectorize.sql
     source: titanic_imputed_test
     create_table: test
+  +whole_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed
+    create_table: whole_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
+  +train_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed_train
+    create_table: train_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
+  +test_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed_test
+    create_table: test_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
 +main:
   +train:
     +train_0:
       td>: queries/train_randomforest_classifier.sql
-      source: train
+      source: train_dense
       create_table: model_rf
   +predict:
     +seq_0:
       +exec_predict:
         td>: queries/predict_randomforest_classifier.sql
-        target_table: test
+        target_table: test_dense
         create_table: prediction
         model_table: model_rf
       +evaluate:
         td>: queries/evaluate.sql
-        actual: test
+        actual: test_dense
         predicted_table: prediction
         predicted_column: probability
         store_last_results: true

--- a/molehill/model/__init__.py
+++ b/molehill/model/__init__.py
@@ -2,4 +2,4 @@ from .linear_model import train_classifier, train_regressor
 from .linear_model import predict_classifier, predict_regressor
 from .tree_model import train_randomforest_classifier, train_randomforest_regressor
 from .tree_model import predict_randomforest_classifier, predict_randomforest_regressor
-from .tree_model import extract_attrs, TREE_MODEL_TRAINERS, TREE_MODEL_PREDICTORS
+from .tree_model import _extract_attrs, TREE_MODEL_TRAINERS, TREE_MODEL_PREDICTORS

--- a/molehill/model/__init__.py
+++ b/molehill/model/__init__.py
@@ -2,4 +2,4 @@ from .linear_model import train_classifier, train_regressor
 from .linear_model import predict_classifier, predict_regressor
 from .tree_model import train_randomforest_classifier, train_randomforest_regressor
 from .tree_model import predict_randomforest_classifier, predict_randomforest_regressor
-from .tree_model import extract_attrs
+from .tree_model import extract_attrs, TREE_MODEL_TRAINERS, TREE_MODEL_PREDICTORS

--- a/molehill/model/tree_model.py
+++ b/molehill/model/tree_model.py
@@ -19,7 +19,6 @@ def _base_train_query(
         source_table: str,
         target: str,
         option: Optional[str],
-        bias: bool = False,
         hashing: bool = False,
         oversample_pos_n_times: Optional[Union[int, str]] = None) -> str:
 
@@ -29,7 +28,6 @@ def _base_train_query(
         target,
         source_table,
         option,
-        bias=bias,
         hashing=hashing,
         with_clause=True,
         oversample_pos_n_times=oversample_pos_n_times)
@@ -46,7 +44,6 @@ def train_randomforest_classifier(
         source_table: str = "${source}",
         target: str = "label",
         option: Optional[str] = None,
-        bias: bool = False,
         hashing: bool = False,
         oversample_pos_n_times: Optional[Union[int, str]] = None,
         **kwargs) -> str:
@@ -61,8 +58,6 @@ def train_randomforest_classifier(
         Target column for prediction
     option : :obj:`str`, optional
         An option string for specific algorithm.
-    bias : bool
-        Add bias or not. Default: False
     hashing : bool
         Execute feature hashing. Default: False
     oversample_pos_n_times : int or :obj:`str`, optional
@@ -79,7 +74,6 @@ def train_randomforest_classifier(
         source_table,
         target,
         option,
-        bias,
         hashing,
         oversample_pos_n_times)
 
@@ -88,7 +82,6 @@ def train_randomforest_regressor(
         source_table: str = "${source}",
         target: str = "label",
         option: Optional[str] = None,
-        bias: bool = False,
         hashing: bool = False,
         oversample_pos_n_times: Optional[Union[int, str]] = None,
         **kwargs) -> str:
@@ -103,8 +96,6 @@ def train_randomforest_regressor(
         Source table name. Default: "training"
     option : :obj:`str`, optional
         An option string for specific algorithm.
-    bias : bool
-        Add bias or not. Default: False
     hashing : bool
         Execute feature hashing. Default: False
     oversample_pos_n_times : int or :obj:`str`, optional
@@ -121,7 +112,6 @@ def train_randomforest_regressor(
         source_table,
         target,
         option,
-        bias,
         hashing,
         oversample_pos_n_times)
 
@@ -131,12 +121,10 @@ def _build_prediction_query(
         id_column: str,
         model_table: str,
         classification: bool = False,
-        bias: bool = False,
         hashing: bool = False) -> str:
 
     _features = "t.features"
     _features = f"feature_hashing({_features})" if hashing else _features
-    _features = f"add_bias({_features})" if bias else _features
 
     query = textwrap.dedent("""\
     with ensembled as (
@@ -178,7 +166,6 @@ def predict_randomforest_classifier(
         target_table: str = "${target_table}",
         id_column: str = "rowid",
         model_table: str = "${model_table}",
-        bias: bool = False,
         hashing: bool = False) -> Tuple[str, str]:
     """Build prediction query for randomforest classifier.
 
@@ -190,8 +177,6 @@ def predict_randomforest_classifier(
         Id column name. Default: "rowid"
     model_table : :obj:`str`
         Model table name.
-    bias : bool
-        Add bias or not. Default: False
     hashing : bool
         Execute feature hashing. Default: False
 
@@ -204,14 +189,13 @@ def predict_randomforest_classifier(
     """
 
     return _build_prediction_query(target_table, id_column, model_table,
-                                   classification=True, bias=bias, hashing=hashing), "probability"
+                                   classification=True, hashing=hashing), "probability"
 
 
 def predict_randomforest_regressor(
         target_table: str = "${target_table}",
         id_column: str = "rowid",
         model_table: str = "${model_table}",
-        bias: bool = False,
         hashing: bool = False) -> Tuple[str, str]:
     """Build prediction query for randomforest_regressor.
 
@@ -223,8 +207,6 @@ def predict_randomforest_regressor(
         Id column name. Default: "rowid"
     model_table : :obj:`str`
         Model table name.
-    bias : bool
-        Add bias or not. Default: False
     hashing : bool
         Execute feature hashing. Default: False
 
@@ -237,4 +219,4 @@ def predict_randomforest_regressor(
     """
 
     return _build_prediction_query(target_table, id_column, model_table,
-                                   bias=bias, hashing=hashing), "target"
+                                   hashing=hashing), "target"

--- a/molehill/model/tree_model.py
+++ b/molehill/model/tree_model.py
@@ -5,6 +5,10 @@ from .base import base_model
 from ..utils import build_query
 
 
+TREE_MODEL_TRAINERS = ['train_randomforest_classifier', 'train_randomforest_regressor']
+TREE_MODEL_PREDICTORS = ['predict_randomforest_classifier', 'predict_randomforest_regressor']
+
+
 def extract_attrs(categorical_columns: List[str], numerical_columns: List[str]) -> str:
     attr_list = ['Q'] * len(numerical_columns) + ['C'] * len(categorical_columns)
     return f"-attrs {','.join(attr_list)}"

--- a/molehill/pipeline.py
+++ b/molehill/pipeline.py
@@ -6,11 +6,12 @@ from typing import Optional, List, Tuple, Any, Dict, Union
 from pathlib import Path
 from .preprocessing import shuffle, train_test_split
 from .preprocessing import Imputer, Normalizer
-from .preprocessing import vectorize
+from .preprocessing import vectorize, cardinality
 from .preprocessing import downsampling_rate
 from .evaluation import evaluate
 from .stats import compute_stats, combine_train_test_stats
 from .utils import build_query
+from .model import TREE_MODEL_TRAINERS, TREE_MODEL_PREDICTORS
 
 
 def _represent_odict(dumper, instance):
@@ -31,8 +32,6 @@ class Pipeline:
     def __init__(self):
         self.comp_stats_task = None
         self.combine_stats_path = None
-        self.vectorize_target_train = None
-        self.vectorize_target_test = None
         self.workflow_path = None
         self.query_dir = None
         self.columns = []
@@ -203,16 +202,37 @@ class Pipeline:
 
         return exec_tasks, vectorize_target_train, vectorize_target_test
 
+    def _build_cardinality_task(
+            self,
+            source: str):
+
+        cardinality_query = cardinality("${source}", self.categorical_columns)
+        query_path = str(self.query_dir / "cardinality.sql")
+        self.save_query(query_path, cardinality_query)
+
+        return od({
+            "+compute_cardinality": od({
+                "td>": query_path,
+                "engine": "presto",
+                "source": source,
+                "store_last_results": True
+            })
+        })
+
     def _build_vectorize_task(
             self,
             conf: Dict[str, Any],
             source: str,
             source_train: str,
-            source_test: str) -> Tuple[OrderedDict, str, str]:
+            source_test: str,
+            require_dense: bool = False,
+            hashing_tree: bool = False) -> Tuple[OrderedDict, str, str]:
 
         train_table = conf.pop("train_table", "train")
         test_table = conf.pop("test_table", "test")
         whole_table = conf.pop("whole_table", "whole")
+        dense_opt = conf.pop("dense", {})
+        dense_mode = dense_opt.get("mode", "auto")
 
         vect_default_opt = {"categorical_columns": self.categorical_columns,
                             "numerical_columns": self.numerical_columns,
@@ -240,6 +260,43 @@ class Pipeline:
             })
         })
 
+        if dense_mode == "force" or (require_dense and dense_mode == "auto"):
+            feature_cardinality = dense_opt.get("feature_cardinality", "auto")
+            hashing_tree = dense_opt.get("hashing", True)
+
+            if feature_cardinality == 'auto':
+                feature_cardinality = "${td.last_results.max_categorical_cardinality} * 10"
+
+            additional_opt = {'dense': True}
+            if feature_cardinality:
+                additional_opt['feature_cardinality'] = "${feature_cardinality}"
+            if hashing_tree:
+                additional_opt['hashing'] = True
+
+            _vect_default_opt = dict(vect_default_opt, **additional_opt)
+            vectorize_dense_query = vectorize("${source}", self.target_column, **dict(_vect_default_opt, **conf))
+            vectorize_dense_path = self.query_dir / "vectorize_dense.sql"
+            self.save_query(vectorize_dense_path, vectorize_dense_query)
+
+            vectorize_task["+whole_dense"] = od({
+                "td>": str(vectorize_dense_path),
+                "source": source,
+                "create_table": whole_table + '_dense',
+                "feature_cardinality": feature_cardinality
+            })
+            vectorize_task["+train_dense"] = od({
+                "td>": str(vectorize_dense_path),
+                "source": source_train,
+                "create_table": train_table + '_dense',
+                "feature_cardinality": feature_cardinality
+            })
+            vectorize_task["+test_dense"] = od({
+                "td>": str(vectorize_dense_path),
+                "source": source_test,
+                "create_table": test_table + '_dense',
+                "feature_cardinality": feature_cardinality
+            })
+
         return vectorize_task, train_table, test_table
 
     def _build_train_task(
@@ -251,7 +308,7 @@ class Pipeline:
         func_name = config.pop('name')
         train_func = getattr(mod, func_name)
 
-        if func_name == 'train_randomforest_classifier' and config.pop('guess_attrs', None):
+        if func_name in TREE_MODEL_TRAINERS and config.pop('guess_attrs', None):
             from .model import extract_attrs
             _opt = config.get('option', '')
             _opt += ' ' + extract_attrs(self.categorical_columns, self.numerical_columns)
@@ -326,6 +383,22 @@ class Pipeline:
             "+show_accuracy": {"echo>": acc_str}
         })
 
+    @staticmethod
+    def _require_dense_vector(config: OrderedDict) -> Tuple[bool, bool]:
+        trainers = config.get('trainer', None)
+
+        if trainers is None:
+            return False, False
+
+        exist_tree = False
+        hashing_tree = False
+        for trainer in trainers:
+            if trainer['name'] in TREE_MODEL_TRAINERS:
+                exist_tree = True
+                hashing_tree = trainer.get('hashing', False)
+
+        return exist_tree, hashing_tree
+
     def dump_pipeline(
             self,
             config_file: str,
@@ -388,6 +461,8 @@ class Pipeline:
         do_imputation = len(self.imputation_clauses) > 0
         do_normalization = len(self.normalization_clauses) > 0
 
+        require_dense_vector, hashing_tree = self._require_dense_vector(config)
+
         vectorize_target_train = f"{source}_train"
         vectorize_target_test = f"{source}_test"
         vectorize_target_whole = f"{source}_shuffled"
@@ -426,9 +501,13 @@ class Pipeline:
 
         workflow["+preparation"] = preparation
 
+        if require_dense_vector and hashing_tree:
+            workflow["+compute_cardinality"] = self._build_cardinality_task(vectorize_target_train)
+
         workflow["+vectorization"], train_table, test_table = self._build_vectorize_task(
             config.get("vectorizer", {}), source=vectorize_target_whole,
-            source_train=vectorize_target_train, source_test=vectorize_target_test)
+            source_train=vectorize_target_train, source_test=vectorize_target_test,
+            require_dense=require_dense_vector, hashing_tree=hashing_tree)
 
         # Preparation for loading train/predict functions dynamically
         __import__('molehill.model')

--- a/molehill/preprocessing/__init__.py
+++ b/molehill/preprocessing/__init__.py
@@ -3,3 +3,4 @@ from .normalization import Normalizer
 from .shuffle import shuffle, train_test_split
 from .vectorization import vectorize
 from .downsample_rate import downsampling_rate
+from .cardinality import cardinality

--- a/molehill/preprocessing/cardinality.py
+++ b/molehill/preprocessing/cardinality.py
@@ -1,0 +1,12 @@
+from typing import List
+from ..utils import build_query
+
+
+def cardinality(
+        source: str,
+        categorical_columns: List[str]) -> str:
+
+    cols = [f"approx_distinct({column})" for column in categorical_columns]
+    select_clause = f"array_max(array[{', '.join(cols)}]) as max_categorical_cardinality"
+
+    return build_query([select_clause], source)

--- a/molehill/preprocessing/vectorization.py
+++ b/molehill/preprocessing/vectorization.py
@@ -148,7 +148,7 @@ def _build_feature_array_dense(
         hashing: bool = False,
         feature_cardinality: Optional[Union[int, str]] = None):
 
-    target_columns = numerical_columns
+    target_columns = numerical_columns.copy()
 
     if hashing:
         _feature_size = f", {feature_cardinality}" if feature_cardinality else ''

--- a/molehill/preprocessing/vectorization.py
+++ b/molehill/preprocessing/vectorization.py
@@ -1,5 +1,5 @@
 from textwrap import indent
-from typing import List, Optional
+from typing import List, Optional, Union
 from ..utils import build_query
 
 
@@ -18,7 +18,7 @@ def vectorize(
         emit_null: bool = False,
         force_value: bool = False,
         dense: bool = False,
-        feature_cardinality: Optional[int] = None) -> str:
+        feature_cardinality: Optional[Union[int, str]] = None) -> str:
     """Build vectorization query before training or prediction.
 
     Parameters
@@ -46,7 +46,7 @@ def vectorize(
         Force to output value as 1 for categorical columns. Default: False
     dense : bool
         Create dense feature vector. Default: False
-    feature_cardinality : int, optional
+    feature_cardinality : int or :obj:`str`, optional
         Max feature size for feature hashing.
 
     Returns
@@ -146,7 +146,7 @@ def _build_feature_array_dense(
         categorical_columns: List[str],
         numerical_columns: List[str],
         hashing: bool = False,
-        feature_cardinality: Optional[int] = None):
+        feature_cardinality: Optional[Union[int, str]] = None):
 
     target_columns = numerical_columns
 

--- a/resources/titanic_pipeline_rf_standardize.yml
+++ b/resources/titanic_pipeline_rf_standardize.yml
@@ -1,0 +1,66 @@
+# Same example with https://scikit-learn.org/stable/auto_examples/compose/plot_column_transformer_mixed_types.html
+source: titanic
+dbname: ml_tips
+train_sample_rate: 0.8
+
+query_dir: queries_std
+
+id_column: "rowid"
+target_column: "survived"
+
+#stratify: true
+
+numerical_columns:
+  - columns:
+      - "age"
+      - "fare"
+    transformer:
+      imputer:
+        strategy: "median" # median, mean, constant
+        phase: "train" # train, test, or null (whole dataset to get stats)
+      normalizer:
+        strategy: "standardize"  # standardize, log1p, minmax
+        phase: "train"
+
+categorical_columns:
+  - columns:
+      - "embarked"
+      - "sex"
+      - "pclass"
+    transformer:
+      imputer:
+        strategy: "constant"
+        phase: "train"
+        fill_value: "missing"
+        # quantify: true # Not implemented yet
+
+vectorizer:
+  train_table: "train"
+  test_table: "test"
+  # emit_null: true
+  # bias: true
+  dense:
+    mode: "auto" # auto or force. Default: auto
+    hashing: true # true or false. Default: true
+    feature_cardinality: "auto" # "auto" or integer, which represents maximum cardinality of categorical columns
+
+# Not implemented yet
+tuner:
+  strategy: "gridsearch" # gridsearch, randomsearch, python
+
+trainer:
+  - name: "train_randomforest_classifier"
+    model_table: "model_rf"
+    option: "-trees 15 -seed 31"
+    # source_table: "train" # Set if you want to set specific table name
+
+predictor:
+  - name: "predict_randomforest_classifier"
+    model_table: "model_rf"
+    output_table: "prediction"
+    # target_table: "test" # Set if you want to set specific table name
+
+evaluator:
+  metrics:
+    - auc
+    - logloss

--- a/tests/model/test_tree_model.py
+++ b/tests/model/test_tree_model.py
@@ -1,16 +1,28 @@
+import pytest
 from molehill.model import train_randomforest_classifier, train_randomforest_regressor
 from molehill.model import predict_randomforest_classifier, predict_randomforest_regressor
-from molehill.model import extract_attrs
+from molehill.model import _extract_attrs
 
 
-def test_extract_attrs():
-    assert extract_attrs(['cat1', 'cat2'], ['num1', 'num2', 'num3']) == '-attrs Q,Q,Q,C,C'
-    assert extract_attrs([], ['num1', 'num2', 'num3']) == '-attrs Q,Q,Q'
-    assert extract_attrs(['cat1', 'cat2'], []) == '-attrs C,C'
+@pytest.fixture
+def categorical_cols():
+    return ['cat1', 'cat2']
 
 
-def test_train_randomforest_classifier():
-    ret_sql = """\
+@pytest.fixture
+def numerical_cols():
+    return ['num1', 'num2', 'num3']
+
+
+def test_extract_attrs(categorical_cols, numerical_cols):
+    assert _extract_attrs(categorical_cols, numerical_cols) == '-attrs Q,Q,Q,C,C'
+    assert _extract_attrs([], numerical_cols) == '-attrs Q,Q,Q'
+    assert _extract_attrs(categorical_cols, []) == '-attrs C,C'
+
+
+class TestSparseTrainModel:
+    def test_train_randomforest_classifier(self):
+        ret_sql = """\
 with models as (
   select
     train_randomforest_classifier(
@@ -36,11 +48,10 @@ group by 1, 2, 3, 5, 6
 ;
 """
 
-    assert train_randomforest_classifier("src_tbl", "target_val", "-trees 16") == ret_sql
+        assert train_randomforest_classifier("src_tbl", "target_val", "-trees 16", sparse=True) == ret_sql
 
-
-def test_train_randomforest_regressor():
-    ret_sql = """\
+    def test_train_randomforest_regressor(self):
+        ret_sql = """\
 with models as (
   select
     train_randomforest_regressor(
@@ -65,7 +76,43 @@ group by 1, 2, 3, 5, 6
 ;
 """
 
-    assert train_randomforest_regressor("src_tbl", "target_val") == ret_sql
+        assert train_randomforest_regressor("src_tbl", "target_val", sparse=True) == ret_sql
+
+
+class TestDenseTrainModel:
+    def test_train_randomforest_classifier(self, categorical_cols, numerical_cols):
+        ret_sql = """\
+select
+  train_randomforest_classifier(
+    features
+    , target_val
+    , '-trees 16 -attrs Q,Q,Q,C,C'
+  )
+from
+  src_tbl
+;
+"""
+
+        assert train_randomforest_classifier(
+            "src_tbl", "target_val", "-trees 16",
+            categorical_columns=categorical_cols, numerical_columns=numerical_cols) == ret_sql
+
+    def test_train_randomforest_regressor(self, categorical_cols, numerical_cols):
+        ret_sql = """\
+select
+  train_randomforest_regressor(
+    features
+    , target_val
+    , '-attrs Q,Q,Q,C,C'
+  )
+from
+  src_tbl
+;
+"""
+
+        assert train_randomforest_regressor(
+            "src_tbl", "target_val",
+            categorical_columns=categorical_cols, numerical_columns=numerical_cols) == ret_sql
 
 
 class TestPredictClassifier:
@@ -180,42 +227,6 @@ from
         assert pred_sql == ret_sql
         assert pred_col == "target"
 
-    def test_predict_regressor_bias(self):
-        ret_sql = """\
-with ensembled as (
-  select
-    id,
-    rf_ensemble(predicted.value, predicted.posteriori, model_weight) as predicted
-  from (
-    select
-      t.id,
-      p.model_weight,
-      tree_predict(p.model_id, p.model, add_bias(t.features)) as predicted
-    from (
-      select
-        model_id, model_weight, model
-      from
-        model_tbl
-      DISTRIBUTE BY rand(1)
-    ) p
-    left outer join target_tbl t
-  ) t1
-  group by
-    id
-)
--- DIGDAG_INSERT_LINE
-select
-  id,
-  predicted.label,
-  predicted.probabilities[1] as probability
-from
-  ensembled
-;
-"""
-        pred_sql, pred_col = predict_randomforest_regressor("target_tbl", "id", "model_tbl", bias=True)
-        assert pred_sql == ret_sql
-        assert pred_col == "target"
-
     def test_predict_regressor_hashing(self):
         ret_sql = """\
 with ensembled as (
@@ -252,38 +263,3 @@ from
         assert pred_sql == ret_sql
         assert pred_col == "target"
 
-    def test_predict_regressor_bias_hashing(self):
-        ret_sql = """\
-with ensembled as (
-  select
-    id,
-    rf_ensemble(predicted.value, predicted.posteriori, model_weight) as predicted
-  from (
-    select
-      t.id,
-      p.model_weight,
-      tree_predict(p.model_id, p.model, add_bias(feature_hashing(t.features))) as predicted
-    from (
-      select
-        model_id, model_weight, model
-      from
-        model_tbl
-      DISTRIBUTE BY rand(1)
-    ) p
-    left outer join target_tbl t
-  ) t1
-  group by
-    id
-)
--- DIGDAG_INSERT_LINE
-select
-  id,
-  predicted.label,
-  predicted.probabilities[1] as probability
-from
-  ensembled
-;
-"""
-        pred_sql, pred_col = predict_randomforest_regressor("target_tbl", "id", "model_tbl", bias=True, hashing=True)
-        assert pred_sql == ret_sql
-        assert pred_col == "target"

--- a/tests/model/test_tree_model.py
+++ b/tests/model/test_tree_model.py
@@ -106,42 +106,6 @@ from
         assert pred_sql == ret_sql
         assert pred_col == "probability"
 
-    def test_predict_randomforest_classifier_bias(self):
-        ret_sql = """\
-with ensembled as (
-  select
-    id,
-    rf_ensemble(predicted.value, predicted.posteriori, model_weight) as predicted
-  from (
-    select
-      t.id,
-      p.model_weight,
-      tree_predict(p.model_id, p.model, add_bias(t.features), "-classification") as predicted
-    from (
-      select
-        model_id, model_weight, model
-      from
-        model_tbl
-      DISTRIBUTE BY rand(1)
-    ) p
-    left outer join target_tbl t
-  ) t1
-  group by
-    id
-)
--- DIGDAG_INSERT_LINE
-select
-  id,
-  predicted.label,
-  predicted.probabilities[1] as probability
-from
-  ensembled
-;
-"""
-        pred_sql, pred_col = predict_randomforest_classifier("target_tbl", "id", "model_tbl", bias=True)
-        assert pred_sql == ret_sql
-        assert pred_col == "probability"
-
     def test_predict_randomforest_classifier_hashing(self):
         ret_sql = """\
 with ensembled as (
@@ -175,42 +139,6 @@ from
 ;
 """
         pred_sql, pred_col = predict_randomforest_classifier("target_tbl", "id", "model_tbl", hashing=True)
-        assert pred_sql == ret_sql
-        assert pred_col == "probability"
-
-    def test_predict_randomforest_classifier_bias_hashing(self):
-        ret_sql = """\
-with ensembled as (
-  select
-    id,
-    rf_ensemble(predicted.value, predicted.posteriori, model_weight) as predicted
-  from (
-    select
-      t.id,
-      p.model_weight,
-      tree_predict(p.model_id, p.model, add_bias(feature_hashing(t.features)), "-classification") as predicted
-    from (
-      select
-        model_id, model_weight, model
-      from
-        model_tbl
-      DISTRIBUTE BY rand(1)
-    ) p
-    left outer join target_tbl t
-  ) t1
-  group by
-    id
-)
--- DIGDAG_INSERT_LINE
-select
-  id,
-  predicted.label,
-  predicted.probabilities[1] as probability
-from
-  ensembled
-;
-"""
-        pred_sql, pred_col = predict_randomforest_classifier("target_tbl", "id", "model_tbl", bias=True, hashing=True)
         assert pred_sql == ret_sql
         assert pred_col == "probability"
 

--- a/tests/preprocessing/test_vectorization.py
+++ b/tests/preprocessing/test_vectorization.py
@@ -135,6 +135,35 @@ from
     assert vectorize('src_tbl', 'target', cat_cols, num_cols, hashing=True) == ret_sql
 
 
+def test_vectorize_with_hashing_cardinality(cat_cols, num_cols):
+    ret_sql = """\
+select
+  rowid
+  , feature_hashing(
+    array_concat(
+      quantitative_features(
+        array("num1", "num2")
+        , num1
+        , num2
+      ),
+      categorical_features(
+        array("cat1", "cat2", "cat3")
+        , cat1
+        , cat2
+        , cat3
+      )
+    )
+    , '-num_features 100'
+  ) as features
+  , target
+from
+  src_tbl
+;
+"""
+
+    assert vectorize('src_tbl', 'target', cat_cols, num_cols, hashing=True, feature_cardinality=100) == ret_sql
+
+
 def test_vectorize_with_bias_hashing(cat_cols, num_cols):
     ret_sql = """\
 select
@@ -246,3 +275,46 @@ from
 """
 
     assert vectorize('src_tbl', 'target', cat_cols, num_cols, emit_null=True, force_value=True) == ret_sql
+
+
+def test_vectorize_dense(cat_cols, num_cols):
+    ret_sql = """\
+select
+  rowid
+  , array(num1, num2, cat1, cat2, cat3) as features
+  , target
+from
+  src_tbl
+;
+"""
+
+    assert vectorize('src_tbl', 'target', cat_cols, num_cols, dense=True) == ret_sql
+
+
+def test_vectorize_dense_with_hashing(cat_cols, num_cols):
+    ret_sql = """\
+select
+  rowid
+  , array(num1, num2, mhash(cat1), mhash(cat2), mhash(cat3)) as features
+  , target
+from
+  src_tbl
+;
+"""
+
+    assert vectorize('src_tbl', 'target', cat_cols, num_cols, dense=True, hashing=True) == ret_sql
+
+
+def test_vectorize_dense_with_hashing_cardinality(cat_cols, num_cols):
+    ret_sql = """\
+select
+  rowid
+  , array(num1, num2, mhash(cat1, 100), mhash(cat2, 100), mhash(cat3, 100)) as features
+  , target
+from
+  src_tbl
+;
+"""
+
+    assert vectorize('src_tbl', 'target', cat_cols, num_cols,
+                     dense=True, hashing=True, feature_cardinality=100) == ret_sql

--- a/tests/resources/queries_rf/train_randomforest_classifier.sql
+++ b/tests/resources/queries_rf/train_randomforest_classifier.sql
@@ -1,23 +1,9 @@
-with models as (
-  select
-    train_randomforest_classifier(
-      feature_hashing(features)
-      , survived
-      , '-trees 15 -seed 31'
-    )
-  from
-    ${source}
-)
--- DIGDAG_INSERT_LINE
 select
-  model_id
-  , model_weight
-  , model
-  , concat_ws(',', collect_set(concat(k1, ':', v1))) as var_importance
-  , oob_errors
-  , oob_tests
+  train_randomforest_classifier(
+    feature_hashing(features)
+    , survived
+    , '-trees 15 -seed 31 -attrs Q,Q,C,C,C'
+  )
 from
-  models
-lateral view explode(var_importance) t1 as k1, v1
-group by 1, 2, 3, 5, 6
+  ${source}
 ;

--- a/tests/resources/titanic_rf.dig
+++ b/tests/resources/titanic_rf.dig
@@ -57,6 +57,11 @@ _export:
         engine: presto
         source: titanic_test
         create_table: titanic_imputed_test
++compute_cardinality:
+  td>: queries/cardinality.sql
+  engine: presto
+  source: titanic_imputed_train
+  store_last_results: true
 +vectorization:
   _parallel: true
   +whole:
@@ -71,22 +76,37 @@ _export:
     td>: queries/vectorize.sql
     source: titanic_imputed_test
     create_table: test
+  +whole_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed
+    create_table: whole_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
+  +train_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed_train
+    create_table: train_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
+  +test_dense:
+    td>: queries/vectorize_dense.sql
+    source: titanic_imputed_test
+    create_table: test_dense
+    feature_cardinality: ${td.last_results.max_categorical_cardinality} * 10
 +main:
   +train:
     +train_0:
       td>: queries/train_randomforest_classifier.sql
-      source: train
+      source: train_dense
       create_table: model_rf
   +predict:
     +seq_0:
       +exec_predict:
         td>: queries/predict_randomforest_classifier.sql
-        target_table: test
+        target_table: test_dense
         create_table: prediction
         model_table: model_rf
       +evaluate:
         td>: queries/evaluate.sql
-        actual: test
+        actual: test_dense
         predicted_table: prediction
         predicted_column: probability
         store_last_results: true


### PR DESCRIPTION
Since Hivemall's RandomForest for sparse input is based on the different algorithm from dense input, it is appropriate to convert a sparse vector into a dense vector. 